### PR TITLE
Fixed a statement that typically has no effect.

### DIFF
--- a/Sources/SAT/Clause.swift
+++ b/Sources/SAT/Clause.swift
@@ -84,7 +84,7 @@ struct Clause {
         if found.isNegative == variable.isNegative {
             return variables.count == 1 ? .clauseUnchanged : .clauseObviated
         }
-        variables.remove(variable)
+        variables.remove(found)
         return .removedVariable
     }
 


### PR DESCRIPTION
Every cnf file I tested caused stack overflows. I think a simple mixup is to blame. This pull request changes a line which had no effect, leading to successive recursions being the same.

Prior to this pull request, the affected line attempts to remove `variable` from `variables`. However, the preceeding logic in the function guarantees that `variable` will *not* be present in `variables` – (since it has a different `isNegative` state from the variable actually found).

I think the intention is to remove the `found` variable. Making this change eliminates the stack overflow in my testing and appears to make the `isSatisfiable` solver functional (although I haven't done exhaustive testing).